### PR TITLE
read midi input, avoiding issues from always-full buffer

### DIFF
--- a/firmware/bleached/bleached.ino
+++ b/firmware/bleached/bleached.ino
@@ -88,7 +88,7 @@ uint16_t loop_count = 0;
 
 void setup() {
   // serial monitoring for debugging
-  Serial.begin(38400);
+  // Serial.begin(38400);
 
   // potentiometers
   analogReadResolution(POT_BIT_RES);
@@ -105,6 +105,10 @@ void loop() {
       prev_pot_val[i] = pot_val;
     }
   }
+
+  // MIDI Controllers should discard incoming MIDI messages.
+  // (reference: https://www.pjrc.com/teensy/td_midi.html)
+  while (usbMIDI.read()) { ;; }
 
   // Periodically send MIDI CC for every knob so that the receiving end matches the knobs
   // even when changing pure data patches.


### PR DESCRIPTION
see here:
https://www.pjrc.com/teensy/td_midi.html

when connected to a host that is sending midi, it is important to clear the input buffer. otherwise the host device/software is liable to stall or do other bad stuff.

(er, i should say that i have not actually tested this myself, going by 2nd-hand reports.)

-----

oh right: also commented out the serial port initialization, since its unused; (and in the context of norns means the host is trying to figure out what to do with a non-functional usb-serial port.)